### PR TITLE
Setters refactoring + Immutability

### DIFF
--- a/src/DataObject.php
+++ b/src/DataObject.php
@@ -18,7 +18,7 @@ class DataObject
         return Hydrator::hydrate(static::class, $data);
     }
 
-    public function __call($method, $arguments): self
+    public function set(string $propertyName, mixed $value): static
     {
         $reflectionClass = new ReflectionObject($this);
         $properties      = $reflectionClass->getProperties(ReflectionProperty::IS_PUBLIC);
@@ -26,11 +26,16 @@ class DataObject
         foreach ($properties as $property) {
             $name = $property->getName();
 
-            if (Str::camel($name) === Str::camel($method)) {
-                $property->setValue($this, ...$arguments);
+            if (Str::camel($name) === Str::camel($propertyName)) {
+                $property->setValue($this, $value);
             }
         }
 
         return $this;
+    }
+
+    public function __call($method, $arguments): static
+    {
+        return $this->set($method, ...$arguments);
     }
 }

--- a/src/DataObject.php
+++ b/src/DataObject.php
@@ -2,6 +2,7 @@
 
 namespace AntoninMasek\SimpleHydrator;
 
+use AntoninMasek\SimpleHydrator\Support\Str;
 use ReflectionObject;
 use ReflectionProperty;
 
@@ -25,7 +26,7 @@ class DataObject
         foreach ($properties as $property) {
             $name = $property->getName();
 
-            if (Helper::camel($name) === Helper::camel($method)) {
+            if (Str::camel($name) === Str::camel($method)) {
                 $property->setValue($this, ...$arguments);
             }
         }

--- a/src/DataObject.php
+++ b/src/DataObject.php
@@ -20,18 +20,19 @@ class DataObject
 
     public function set(string $propertyName, mixed $value): static
     {
-        $reflectionClass = new ReflectionObject($this);
+        $clone           = clone $this;
+        $reflectionClass = new ReflectionObject($clone);
         $properties      = $reflectionClass->getProperties(ReflectionProperty::IS_PUBLIC);
 
         foreach ($properties as $property) {
             $name = $property->getName();
 
             if (Str::camel($name) === Str::camel($propertyName)) {
-                $property->setValue($this, $value);
+                $property->setValue($clone, $value);
             }
         }
 
-        return $this;
+        return $clone;
     }
 
     public function __call($method, $arguments): static

--- a/src/Support/Str.php
+++ b/src/Support/Str.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace AntoninMasek\SimpleHydrator;
+namespace AntoninMasek\SimpleHydrator\Support;
 
-final class Helper
+final class Str
 {
     public static function camel($value): ?string
     {

--- a/tests/SimpleHydratorTest.php
+++ b/tests/SimpleHydratorTest.php
@@ -134,6 +134,24 @@ class SimpleHydratorTest extends TestCase
         $this->assertSame('John', $person->first_name);
     }
 
+    public function testObjectCanSetValuesUsingSetter()
+    {
+        $person = Human::fromArray($this->data)->set('firstName', 'John');
+        $this->assertSame('John', $person->first_name);
+
+        $person = Human::fromArray($this->data)->set('FirstName', 'Dave');
+        $this->assertSame('Dave', $person->first_name);
+
+        $person = Human::fromArray($this->data)->set('First_Name', 'Pete');
+        $this->assertSame('Pete', $person->first_name);
+
+        $person = Human::fromArray($this->data)->set('First_name', 'Tony');
+        $this->assertSame('Tony', $person->first_name);
+
+        $person = Human::fromArray($this->data)->set('first_name', 'Steve');
+        $this->assertSame('Steve', $person->first_name);
+    }
+
     public function testObjectTypeError()
     {
         $this->expectException(TypeError::class);

--- a/tests/SimpleHydratorTest.php
+++ b/tests/SimpleHydratorTest.php
@@ -152,6 +152,20 @@ class SimpleHydratorTest extends TestCase
         $this->assertSame('Steve', $person->first_name);
     }
 
+    public function testImmutability()
+    {
+        $person = Human::fromArray($this->data);
+        $this->assertSame('John', $person->name);
+
+        $person->set('name', 'Dave');
+        $this->assertSame('John', $person->name);
+
+        $person2 = $person->set('name', 'Dave');
+        $this->assertSame('Dave', $person2->name);
+
+        $this->assertNotSame(spl_object_id($person), spl_object_id($person2));
+    }
+
     public function testObjectTypeError()
     {
         $this->expectException(TypeError::class);


### PR DESCRIPTION
This PR introduces a new way of setting properties without losing IDE autocompletion. It also changes the logic so that `DataObject` is immutable.